### PR TITLE
chore(http port) Jetty failed to start when the Port <= 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ None.
 # Jenkins vars
 jenkins_dest: /opt/jenkins
 jenkins_lib: /var/lib/jenkins
-port: 8081
+jenkins_http_port: 8081
 prefix: '"--prefix=/jenkins/"'
 jenkins:
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
-jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
+jenkins_api_url: "http://localhost:{{ jenkins_http_port }}{{ prefix }}"
 jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"
 java_home: /opt/jdk1.8.0_111
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,16 @@
 # Jenkins vars
 jenkins_dest: /opt/jenkins
 jenkins_lib: /var/lib/jenkins
-port: 8081
+jenkins_http_port: 8081
 prefix: '"--prefix=/jenkins/"'
 jenkins:
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
-jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
+jenkins_api_url: "http://localhost:{{ jenkins_http_port }}{{ prefix }}"
 jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"
 java_home: /opt/jdk1.8.0_111
+jenkins_configs:
+  JENKINS_PORT: "{{ jenkins_http_port }}"
+  JENKINS_JAVA_CMD: "{{ java_home }}/bin/java"
+  JENKINS_ARGS: "{{ prefix }}"
+  JENKINS_USER: "{% if jenkins_http_port < 1025 %}root{% else %}jenkins{% endif %}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,29 +7,16 @@
       path: /etc/sysconfig/jenkins
       state: touch
 
-  - name: Configure Jenkins Port
+  - name: Configure Jenkins
     lineinfile:
       dest: /etc/sysconfig/jenkins
-      regexp: ^JENKINS_PORT=
-      line: JENKINS_PORT={{port}}
+      regexp: "^{{ item.key }}="
+      line: "{{ item.key }}={{ item.value }}"
+    with_dict: "{{ jenkins_configs }}"
+    when: item.value
     register: config_changed
 
-  - name: Configure Jenkins for $JAVA_HOME
-    lineinfile:
-      dest: /etc/sysconfig/jenkins
-      regexp: ^JENKINS_JAVA_CMD=
-      line: JENKINS_JAVA_CMD="{{ java_home }}/bin/java"
-    register: config_changed
-
-  - name: Configure Jenkins Prefix
-    when: prefix is defined
-    lineinfile:
-      dest: /etc/sysconfig/jenkins
-      regexp: ^JENKINS_ARGS=
-      line: JENKINS_ARGS={{prefix}}
-    register: config_changed
-
-  - name: Add jenkins user into sudoers for sudo access
+  - name: Add Jenkins user into sudoers for sudo access
     lineinfile:
       dest: /etc/sudoers
       line: "{{ item.line }}"


### PR DESCRIPTION
# Problem
Jetty failed to starts when port number passed is lower than 1024, since it's reserved for root

# Solution
The default user for Jenkins process will be root when config asks for a lower port.
Also, `port` is a reserved Ansible variable, it was replaced with `jenkins_http_port` to avoid
```
[WARNING]: Found variable using reserved name: port
```

Regex for `/etc/sysconfig/jenkins` are now iterating over a dict in `defaults/main.yml` called `jenkins_configs`. It will simplify the process of adding a new config (which is necessary for `JENKINS_USER`, for example).